### PR TITLE
Install Craco and StyleX

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,3 +118,50 @@ Now with Github Actions installed we can make sure that we run checks on the
 code we are committing when we make a mistake if we view the commit we can see 
 the error popout with a UI similar to this:
 ![image](https://user-images.githubusercontent.com/4765784/119687623-3693db80-bdfc-11eb-813a-8684f896c380.png)
+
+Configure your github repo to prevent pushing directly to main and also to force
+all checks must past before been able to merge code into main.
+
+### Install Craco
+
+Craco will allow to may changes into react-script ecosystem without using eject.
+
+npm install @craco/craco
+
+update on package json the builds from react-scripts to craco
+```
+    "start": "craco start",
+    "build": "craco build",
+    "test": "craco test",
+    "eject": "craco eject",
+```
+
+Create Craco config file (craco.config.js)
+```
+const {ESLINT_MODES} = require("@craco/craco");
+
+module.exports = {
+  babel: {
+    // / ...
+    plugins: [
+      // / ...
+      [
+        "@ladifire-opensource/babel-plugin-transform-stylex",
+        {
+          inject: true,
+        },
+      ],
+    ],
+  },
+  eslint: {
+    mode: ESLINT_MODES.file,
+  },
+};
+
+```
+
+### Install Style X
+
+npm install @ladifire-opensource/stylex
+
+npm install @ladifire-opensource/babel-plugin-transform-stylex

--- a/craco.config.js
+++ b/craco.config.js
@@ -1,0 +1,21 @@
+// eslint-disable-next-line
+const {ESLINT_MODES} = require("@craco/craco");
+
+// eslint-disable-next-line no-undef
+module.exports = {
+  babel: {
+    // / ...
+    plugins: [
+      // / ...
+      [
+        "@ladifire-opensource/babel-plugin-transform-stylex",
+        {
+          inject: true,
+        },
+      ],
+    ],
+  },
+  eslint: {
+    mode: ESLINT_MODES.file,
+  },
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1193,6 +1193,55 @@
         "minimist": "^1.2.0"
       }
     },
+    "@craco/craco": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/@craco/craco/-/craco-6.1.2.tgz",
+      "integrity": "sha512-GlQZn+g+yNlaDvIL5m6mcCoBGyFDwO4kkNx3fNFf98wuldkdWyBFoQbtOFOIb4gvkTh4VntOOxtJEoZfKs7XXw==",
+      "requires": {
+        "cross-spawn": "^7.0.0",
+        "lodash": "^4.17.15",
+        "semver": "^7.3.2",
+        "webpack-merge": "^4.2.2"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+          "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+          "requires": {
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
+          }
+        },
+        "path-key": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
+        },
+        "shebang-command": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+          "requires": {
+            "shebang-regex": "^3.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
+      }
+    },
     "@csstools/convert-colors": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/@csstools/convert-colors/-/convert-colors-1.4.0.tgz",
@@ -1805,6 +1854,75 @@
           }
         }
       }
+    },
+    "@ladifire-opensource/babel-plugin-transform-stylex": {
+      "version": "0.1.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@ladifire-opensource/babel-plugin-transform-stylex/-/babel-plugin-transform-stylex-0.1.0-beta.0.tgz",
+      "integrity": "sha512-8mqry/MMYgNuABFrOK5DMvv88m0jtVctO619E8zoXCYtDNTXjfEwUp1SnyYDHyCTeTJ/ias4aM95AQ13/l499Q==",
+      "requires": {
+        "@babel/template": "^7.10.4",
+        "@babel/types": "^7.8.3",
+        "chalk": "^3.0.0",
+        "known-css-properties": "^0.20.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "@ladifire-opensource/stylex": {
+      "version": "0.1.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@ladifire-opensource/stylex/-/stylex-0.1.0-beta.0.tgz",
+      "integrity": "sha512-1h6Lp0bSeeR6aIeRw8cYaxuv5nuEdzMoa/aoArj06FEjmsoWrztZnRS+U6ZZC9jtrCEfxUHX/v0WSL2zVrTcWw==",
+      "requires": {
+        "@ladifire-opensource/stylex-theme": "0.1.0-beta.0"
+      }
+    },
+    "@ladifire-opensource/stylex-theme": {
+      "version": "0.1.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@ladifire-opensource/stylex-theme/-/stylex-theme-0.1.0-beta.0.tgz",
+      "integrity": "sha512-QvwsJzw5J5OhPfoEIkU0DOGFrFPSgxyboj7IgCCPsbIU5PLAqfVkshAAQPXrqDgwetyg7+pM5YCUQsxIWokPXg=="
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.4",
@@ -9643,6 +9761,11 @@
       "resolved": "https://registry.npmjs.org/klona/-/klona-2.0.4.tgz",
       "integrity": "sha512-ZRbnvdg/NxqzC7L9Uyqzf4psi1OM4Cuc+sJAkQPjO6XkQIJTNbfK2Rsmbw8fx1p2mkZdp2FZYo2+LwXYY/uwIA=="
     },
+    "known-css-properties": {
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.20.0.tgz",
+      "integrity": "sha512-URvsjaA9ypfreqJ2/ylDr5MUERhJZ+DhguoWRr2xgS5C7aGCalXo+ewL+GixgKBfhT2vuL02nbIgNGqVWgTOYw=="
+    },
     "language-subtag-registry": {
       "version": "0.3.21",
       "resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.21.tgz",
@@ -16079,6 +16202,14 @@
           "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
           "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
         }
+      }
+    },
+    "webpack-merge": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-4.2.2.tgz",
+      "integrity": "sha512-TUE1UGoTX2Cd42j3krGYqObZbOD+xF7u28WB7tfUordytSjbWTIjK/8V0amkBfTYN4/pB/GIDlJZZ657BGG19g==",
+      "requires": {
+        "lodash": "^4.17.15"
       }
     },
     "webpack-sources": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@craco/craco": "^6.1.2",
+    "@ladifire-opensource/babel-plugin-transform-stylex": "0.1.0-beta.0",
+    "@ladifire-opensource/stylex": "0.1.0-beta.0",
     "@testing-library/jest-dom": "^5.12.0",
     "@testing-library/react": "^11.2.7",
     "@testing-library/user-event": "^12.8.3",
@@ -18,12 +21,12 @@
     "web-vitals": "^1.1.2"
   },
   "scripts": {
-    "start": "react-scripts start",
-    "build": "react-scripts build",
-    "test": "react-scripts test",
-    "eject": "react-scripts eject",
+    "start": "craco start",
+    "build": "craco build",
+    "test": "craco test",
+    "eject": "craco eject",
     "eslint": "eslint",
-    "tsc" : "tsc"
+    "tsc": "tsc"
   },
   "eslintConfig": {
     "extends": [

--- a/src/@ladifire-opensource/stylex/index.d.ts
+++ b/src/@ladifire-opensource/stylex/index.d.ts
@@ -1,3 +1,9 @@
+/*
+ * Typescript definition updated to allow been able to detect which css rules
+ * were changed. This will allow us to limit the css properties a developer can
+ * change. For example a button might allow to change margins but not padding or
+ * any other css property
+ */
 import * as css from "csstype";
 
 type PseudoStyles = {

--- a/src/@ladifire-opensource/stylex/index.d.ts
+++ b/src/@ladifire-opensource/stylex/index.d.ts
@@ -1,6 +1,3 @@
-// @author: somibuon, Duc Hoang
-// TODO: need more review
-
 import * as css from "csstype";
 
 type PseudoStyles = {

--- a/src/@ladifire-opensource/stylex/index.d.ts
+++ b/src/@ladifire-opensource/stylex/index.d.ts
@@ -1,0 +1,61 @@
+// @author: somibuon, Duc Hoang
+// TODO: need more review
+
+import * as css from "csstype";
+
+type PseudoStyles = {
+  ":first-child"?: css.Properties;
+  ":last-child"?: css.Properties;
+  ":hover"?: css.Properties;
+  ":focus"?: css.Properties;
+  ":selected"?: css.Properties;
+};
+
+type CssStyles = css.Properties & PseudoStyles;
+
+type ClearCSSFields = {
+  [Property in keyof css.Properties]: null;
+};
+export type RemoveUnusedStyles<ApprovedStyles> = {
+  [Property in keyof ClearCSSFields as Exclude<
+    Property,
+    keyof ApprovedStyles
+  >]: null;
+} &
+  ApprovedStyles;
+
+export type Opaque<K, T> = T & {__TYPE__: K};
+export type StyleX$CSS<T> = Opaque<"Styles", RemoveUnusedStyles<T>>;
+export type CompiledStyles<Type extends CssStyles> = {
+  [Property in keyof Omit<Type, keyof PseudoStyles>]: Opaque<
+    "Styles",
+    Type[Property]
+  >;
+};
+
+// tslint:disable-next-line:export-just-namespace
+export = stylex;
+export as namespace stylex;
+
+/* eslint-disable */
+declare function stylex(
+  ...style: (
+    | Opaque<"Styles", {[key: string]: any}>
+    | (null | Opaque<"Styles", {[key: string]: any}>)[]
+  )[]
+): string;
+
+declare namespace stylex {
+  function create<T extends Record<string, CssStyles>>(
+    styles: T,
+  ): CompiledStyles<T>;
+
+  function dedupe(...styles: CssStyles[]): string;
+
+  // TODO: maybe remove in next release
+  function compose(...styles: CssStyles[]): CssStyles;
+
+  function keyframes(rules: CssStyles): string;
+
+  function inject(cssString: string): void;
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
 import "App.css";
+import Button from "Button.react";
 
 function App() {
   return (
@@ -15,6 +16,7 @@ function App() {
         >
           Learn React
         </a>
+        <Button label={"Click"} />
       </header>
     </div>
   );

--- a/src/Button.react.tsx
+++ b/src/Button.react.tsx
@@ -1,0 +1,74 @@
+/*
+ * (c) Sellution. Confidential and propietary
+ *
+ */
+
+import type {StyleX$CSS} from "@ladifire-opensource/stylex";
+import type {Width, Margin} from "types/css";
+
+import stylex from "@ladifire-opensource/stylex";
+
+const styles = stylex.create({
+  disabled: {
+    backgroundColor: "#F7F9FB",
+    border: "1px solid #E7EAEC",
+    color: "#E7EAEC",
+    pointerEvents: "none",
+  },
+  loader: {
+    position: "absolute",
+    right: "8px",
+    top: "0",
+  },
+  root: {
+    backgroundColor: "#4492FC",
+    border: "1px solid #4492FC",
+    borderRadius: "4px",
+    color: "#fff",
+    cursor: "pointer",
+    display: "inline-block",
+    fontSize: "14px",
+    height: "36px",
+    lineHeight: "34px",
+    paddingLeft: "20px",
+    paddingRight: "20px",
+    position: "relative",
+    textAlign: "center",
+  },
+  secondary: {
+    backgroundColor: "#FFF",
+    border: "1px solid #DDD",
+    color: "#3f3f3f",
+  },
+});
+
+type Props = {
+  label: string;
+  isDisabled?: boolean;
+  onClick?: () => void;
+  size?: number;
+  variant?: "primary" | "secondary";
+  xstyle?: StyleX$CSS<Width & Margin>;
+};
+
+export default function Button({
+  label,
+  isDisabled,
+  onClick,
+  xstyle,
+  variant = "primary",
+}: Props) {
+  return (
+    <button
+      className={stylex([
+        styles.root,
+        isDisabled ? styles.disabled : null,
+        variant === "secondary" ? styles.secondary : null,
+        xstyle ?? null,
+      ])}
+      onClick={onClick}
+    >
+      {label}
+    </button>
+  );
+}

--- a/src/types/css/index.tsx
+++ b/src/types/css/index.tsx
@@ -1,0 +1,23 @@
+/*
+ * (c) Sellution. Confidential and propietary
+ *
+ */
+import * as css from "csstype";
+
+export type Margin = Pick<
+  css.Properties,
+  "margin" | "marginLeft" | "marginRight" | "marginTop" | "marginBottom"
+>;
+export type Padding = Pick<
+  css.Properties,
+  "padding" | "paddingLeft" | "paddingRight" | "paddingTop" | "paddingBottom"
+>;
+
+export type Width = Pick<css.Properties, "width">;
+export type Height = Pick<css.Properties, "height">;
+
+export type TextAlign = Pick<css.Properties, "textAlign">;
+export type Position = Pick<
+  css.Properties,
+  "position" | "top" | "bottom" | "left" | "right"
+>;


### PR DESCRIPTION
Craco will allow us to be able to adjust react without using react-scripts eject to perform changes
This was needed to install StyleX which will allow use to have styles in JS but with the advantage 
every single style is atomic and therefore if opacity:0 is used a 100 times is only define once. This also
means that a div with 10 styles, will compile into a div with 10 classes each one with a single css change.